### PR TITLE
Add tracker launchers

### DIFF
--- a/citra-updater.py
+++ b/citra-updater.py
@@ -988,7 +988,7 @@ def typeformatting(typing):
     #               'Ice':'#42bfff', 'Fighting':'#ffa202', 'Poison':'#994dcf', 'Ground':'#ab7939', 'Flying':'#95c9ff',
     #               'Psychic':'#ff637f', 'Bug':'#9fa523', 'Rock':'#bcb889', 'Ghost':'#6e4570', 'Dragon':'#7e44ed', 
     #               'Dark':'#2f4f4f', 'Steel':'#708090', 'Fairy':'#ffb1ff'}
-    typecolor = typecolordict[typing]
+    typecolor = typecolordict.get(typing, '#FFFFFF')
     return typecolor
 
 def natureformatting(nl, s):

--- a/citra-updater.py
+++ b/citra-updater.py
@@ -31,15 +31,6 @@ def install(package):
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
     print(f'Installed package [{package}].')
 
-# Check python version
-min_python_version = (3,12)
-run_ver = (sys.version_info[0], sys.version_info[1])
-if run_ver < min_python_version:
-    print(f"The installed python version is incompatible, you need to install python {'.'.join(map(str,min_python_version))}.0 or later to run this file.")
-    print(f"Installed version: {'.'.join(map(str,run_ver + (sys.version_info[2],)))}")
-    input("Press any key to exit...")
-    exit()
-
 # deprecating using "official" PSG due to paywall - will keep code around just in case other bullshit happens
 # try: # check for PySimpleGUI and install if not present
 #     import PySimpleGUI as sg

--- a/install-instructions.md
+++ b/install-instructions.md
@@ -2,7 +2,9 @@
 
 1. Drop all of these files into the same location as citra.py. This is usually in appdata/local.
 2. Get a pokemon from the bag/lab/etc.
-3. Run the tracker (go to the folder you just dropped your stuff in and try to open the citra-updater.py file)! That's it!
+3. Run the tracker (go to the folder you just dropped your stuff in and use the launcher file)! That's it!
+
+See [here](https://gist.github.com/UTDZac/1db6bbadb9457802d848c4c592d069fd#tracker-setup) for a detailed guide to setting up the tracker from UTDZac.
 
 ### FOR SEED AUTO-ADVANCEMENT ###
 

--- a/launcher_MAC.command
+++ b/launcher_MAC.command
@@ -1,0 +1,22 @@
+#!/bin/bash
+# MAC launcher for the citra tracker
+
+# Run the version check script to test if 3.12 is installed
+python util/python-version-check.py 2> /dev/null
+
+# ERROR LEVELS: 0 - Success, 127 - Fail (python not found), 2 - Fail (incorrect python version)
+case $? in
+127)
+    # Python not found on PATH
+    echo Python is not installed or the PATH was not set during installation.
+    echo Python 3.12 is required to run the tracker. Install from https://www.python.org/
+    echo Check for an "add python to PATH" option and make sure that is enabled.
+    ;;
+0)
+    # Run the tracker
+    echo Launching the Citra Tracker...
+    python citra-updater.py
+    ;;
+esac
+
+read -p "Press any key to exit..."

--- a/launcher_UNIX.sh
+++ b/launcher_UNIX.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# UNIX launcher for the citra tracker
+
+# Run the version check script to test if 3.12 is installed
+python util/python-version-check.py 2> /dev/null
+
+# ERROR LEVELS: 0 - Success, 127 - Fail (python not found), 2 - Fail (incorrect python version)
+case $? in
+127)
+    # Python not found on PATH
+    echo Python is not installed or the PATH was not set during installation.
+    echo Python 3.12 is required to run the tracker. Install from https://www.python.org/
+    echo Check for an "add python to PATH" option and make sure that is enabled.
+    ;;
+0)
+    # Run the tracker
+    echo Launching the Citra Tracker...
+    python citra-updater.py
+    ;;
+esac
+
+read -p "Press any key to exit..."

--- a/launcher_WINDOWS.bat
+++ b/launcher_WINDOWS.bat
@@ -1,0 +1,20 @@
+@echo OFF
+@REM Windows launcher for the citra tracker
+
+@REM Run the version check script to test if 3.12 is installed
+call python util\python-version-check.py 2> nul
+
+@REM ERROR LEVELS: 0 - Success, 1 - Fail (python not found), 2 - Fail (incorrect python version)
+if %ERRORLEVEL%==1 (
+   @REM Python not found on PATH
+   echo Python is not installed or the PATH was not set during installation.
+   echo Python 3.12 is required to run the tracker. Install from https://www.python.org/
+   echo Make sure to check the "Add python.exe to PATH" box in the installer.
+) else if %ERRORLEVEL%==0 (
+   @REM Run the tracker
+   echo Launching the Citra Tracker...
+   call python citra-updater.py
+)
+
+echo Press any key to exit...
+pause>nul

--- a/util/gitcheck.py
+++ b/util/gitcheck.py
@@ -24,7 +24,7 @@ def gitpopup(gitlink):
 
 def gitcheck(v):
     import requests
-    import PySimpleGUI as sg
+    import FreeSimpleGUI as sg
     import webbrowser
     gitapi = 'https://api.github.com/repos/kcblack42/Citra-Tracker-v2/releases/latest'
     gitlink = 'https://github.com/kcblack42/Citra-Tracker-v2/releases/latest'

--- a/util/python-version-check.py
+++ b/util/python-version-check.py
@@ -1,13 +1,10 @@
 import sys
+# Version number tuple required to run the tracker
 min_python_version = (3,12)
+# Check the installed version of python
 run_ver = (sys.version_info[0], sys.version_info[1])
-print (run_ver)
 if run_ver < min_python_version:
-    print(f"The installed python version ({'.'.join(map(str,run_ver + (sys.version_info[2],)))}) is incompatible.")
-    print(f"You need to install python {'.'.join(map(str,min_python_version))}.0 or later to run the citra tracker.")
-    exit(1)
-
-###### DEBUG - for testing, remove later
-print("ALL GOOD")
-######
-exit(0)
+    print(f"The installed python version ({'.'.join(map(str,run_ver + (sys.version_info[2],)))}) is incompatible with the tracker.")
+    print(f"You need to install python {'.'.join(map(str,min_python_version))} or later from https://www.python.org/")
+    # Exit with code 2 to be distinct to the launcher from when python is not on PATH
+    sys.exit(2)

--- a/util/python-version-check.py
+++ b/util/python-version-check.py
@@ -1,0 +1,13 @@
+import sys
+min_python_version = (3,12)
+run_ver = (sys.version_info[0], sys.version_info[1])
+print (run_ver)
+if run_ver < min_python_version:
+    print(f"The installed python version ({'.'.join(map(str,run_ver + (sys.version_info[2],)))}) is incompatible.")
+    print(f"You need to install python {'.'.join(map(str,min_python_version))}.0 or later to run the citra tracker.")
+    exit(1)
+
+###### DEBUG - for testing, remove later
+print("ALL GOOD")
+######
+exit(0)


### PR DESCRIPTION
- Added 3 launcher files for the tracker (Windows, UNIX, Mac) which first run the python version check before running the tracker
  - These should keep the window open if the tracker errors out, allowing people to more easily see the error message for getting help
- The version check is now in its own small python script outside the main tracker to avoid any issues with the installed version not liking some syntax in the main tracker script
- I also added a small fix for the KeyError spams in the console (or at least the one I saw people posting, same fix would apply elsewhere when KeyErrors are raised by a dictionary), and a PSG reference that wasn't updated

I've tested these as best as I can using some pyenv/pipenv hackyness and they seem to work fine, though testing on your end to double-check certainly wouldn't hurt.

I've also never owned a mac so I just kinda copy/pasted the sh script into a .command file which from my understanding would allow double-clicking to run on Mac (sh files are owned by XCode so may just open in an editor there), hopefully it works (they're both set to use bash in the shebang) but also idk how many people are playing gen 6/7 ironmon on mac lmao