### PR TITLE
needed steps for linux

### DIFF
--- a/install-instructions.md
+++ b/install-instructions.md
@@ -1,5 +1,22 @@
 ### INSTALLATION INSTRUCTIONS ###
 
+<details>
+  <summary>ADDITIONAL STEPS ON LINUX</summary>
+
+1. Install `python3`,`python3-pip` and `tk`.
+2. Navigate to citra-linux-appimage-xxxxxxx-xxxxxxx/scripting.
+3. Setup a virtual python environment.
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   ```
+4. Make the launcher executable and run it.
+   ```bash
+   chmod +x launcher-UNIX.sh
+   ./launcher-UNUX.sh
+   ```
+</details>
+
 1. Drop all of these files into the same location as citra.py. This is usually in appdata/local.
 2. Get a pokemon from the bag/lab/etc.
 3. Run the tracker (go to the folder you just dropped your stuff in and use the launcher file)! That's it!

--- a/install-instructions.md
+++ b/install-instructions.md
@@ -7,8 +7,8 @@
 2. Navigate to citra-linux-appimage-xxxxxxx-xxxxxxx/scripting.
 3. Setup a virtual python environment.
    ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
+   python3 -m venv .ironmon
+   source .ironmon/bin/activate
    ```
 4. Make the launcher executable and run it.
    ```bash


### PR DESCRIPTION
Running the Linux script will on most Distros come up with the following error 

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
python3-xyz, where xyz is the package you are trying to
install.

If you wish to install a non-Debian-packaged Python package,
create a virtual environment using python3 -m venv path/to/venv.
Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
sure you have python3-full installed.

If you wish to install a non-Debian packaged Python application,
it may be easiest to use pipx install xyz, which will manage a
virtual environment for you. Make sure you have pipx installed.

See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
This can be resolved or bypassed in some ways 
1. The dumb way add --break-system-packages to your script 
2.  Change the script to use pip-x  (pip-x is usually the way to go if specific programs are needed system-wide which is not the case here 
3.  Create a virtual python environment. 

I have added steps to do the last option to the install manual.